### PR TITLE
ha-addon: version 1.0.1

### DIFF
--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-09-29
+
+- Updated the documentation
+- Fixed apparmor config
+- Bumped BudapestMetroDisplay to 1.0.0
+
 ## [1.0.0] - 2025-09-29
 
 - Updated the documentation

--- a/ha-addon/build.yaml
+++ b/ha-addon/build.yaml
@@ -8,4 +8,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  APP_VERSION: 1.0.0
+  APP_VERSION: 1.1.0

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,7 +1,7 @@
 name: "BudapestMetroDisplay"
 description: "Backgorund service for a BudapestMetroDisplay hardware LED display"
 url: "https://github.com/denes44/BudapestMetroDisplay/tree/main/ha-addon"
-version: "1.0.0"
+version: "1.0.1"
 slug: "budapestmetrodisplay"
 init: false
 legacy: true


### PR DESCRIPTION
This PR bumps the Home Assistant add-on version and updates BudapestMetroDisplay to the latest version.

**Software changelog for 1.1.0**

## [1.1.0] - 2025-08-26

### Changed

- All of the suburban railways LED color is the same as H5 now (purple)
- Dynamically adjust next schedule update date, if the last departure time is sooner
  than the time of the next planned update
- No separate API call just to calculate schedule interval for the routes
- Log entries includes function name instead of thread name