### PR TITLE
ha-addon: version 1.0.2

### DIFF
--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -3,11 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-09-29
+
+- Bumped BudapestMetroDisplay to 1.1.1
+
 ## [1.0.1] - 2025-09-29
 
-- Updated the documentation
-- Fixed apparmor config
-- Bumped BudapestMetroDisplay to 1.0.0
+- Bumped BudapestMetroDisplay to 1.1.0
 
 ## [1.0.0] - 2025-09-29
 

--- a/ha-addon/build.yaml
+++ b/ha-addon/build.yaml
@@ -8,4 +8,4 @@ codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
 args:
-  APP_VERSION: 1.1.0
+  APP_VERSION: 1.1.1

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,7 +1,7 @@
 name: "BudapestMetroDisplay"
 description: "Backgorund service for a BudapestMetroDisplay hardware LED display"
 url: "https://github.com/denes44/BudapestMetroDisplay/tree/main/ha-addon"
-version: "1.0.1"
+version: "1.0.2"
 slug: "budapestmetrodisplay"
 init: false
 legacy: true


### PR DESCRIPTION
This PR bumps the Home Assistant add-on version and updates BudapestMetroDisplay to the latest version.

**Software changelog for 1.1.1**

## [1.1.1] - 2025-09-02

### Fixed
- Fixed calculation of schedule interval time, which in some cases could have
caused the LEDs not to turn on during a departure